### PR TITLE
Use approriate string type from Flow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ class Client {
   }
 
   /** */
-  createStoryComment(storyID: ID, text: String): Promise<StoryComment> {
+  createStoryComment(storyID: ID, text: string): Promise<StoryComment> {
     return this.createResource(`stories/${storyID}/comment`, { text });
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -4,8 +4,8 @@ export type ID = string | number;
 
 interface Entity {
   id: ID,
-  created_at: String,
-  updated_at: String,
+  created_at: string,
+  updated_at: string,
 }
 
 export interface RequestFactory {
@@ -181,8 +181,8 @@ export type EpicChange = {
 
 export type StoryComment = {
   id: ID,
-  created_at: String,
-  updated_at: String,
+  created_at: string,
+  updated_at: string,
 };
 
 /* Task */


### PR DESCRIPTION
This was using the Javascript `String` type instead of Flow's `string` type.