### PR TITLE
Prefer usage of isomorphic-fetch over node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "es6-promise": "^4.1.0",
-    "isomorphic-fetch": "^2.2.1",
-    "node-fetch": "^1.6.3"
+    "isomorphic-fetch": "^2.2.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 /* @flow */
-import fetch from 'node-fetch';
+
+import 'isomorphic-fetch';
 import ClientError from './client_error';
+
 import type {
   Project,
   ProjectChange,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2760,7 +2760,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-fetch@^1.0.1, node-fetch@^1.6.3:
+node-fetch@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
   dependencies:


### PR DESCRIPTION
This will let the module be used across targets.