### PR TITLE
Upgrade to the latest version of Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,4 +7,4 @@
 [options]
 
 [version]
-0.42.0
+0.49.1

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.0.1",
-    "flow-bin": "^0.42.0",
+    "flow-bin": "^0.49.1",
     "flow-copy-source": "^1.1.0",
     "jest": "^19.0.2",
     "prettier": "^1.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -46,11 +46,7 @@ class TokenRequestFactory implements RequestFactory {
     this.token = token;
   }
 
-  makeRequest(
-    url: string,
-    method?: MethodType = 'GET',
-    body?: Object,
-  ): Promise<*> {
+  makeRequest(url: string, method?: string = 'GET', body?: Object): Promise<*> {
     const urlWithToken = `${url}?token=${this.token}`;
     const headers = {
       Accept: 'application/json',

--- a/src/types.js
+++ b/src/types.js
@@ -9,7 +9,7 @@ interface Entity {
 }
 
 export interface RequestFactory {
-  makeRequest(uri: string, method?: MethodType, body?: Object): Promise<*>,
+  makeRequest(uri: string, method?: string, body?: Object): Promise<*>,
 }
 
 /* Users */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,9 +1726,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.42.0:
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.42.0.tgz#05dd754b6b052de7b150f9210e2160746961e3cf"
+flow-bin@^0.49.1:
+  version "0.49.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
 
 flow-copy-source@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This removes the explicit `MethodType` enum value in favor of a generic
string value.