### PR TITLE
Refactor internals to use more dependency injection

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,17 @@
 {
   "presets": [
-    "es2015",
-    "stage-2",
-    "env",
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["last 2 versions", "safari >= 7"],
+          "node": "6.0"
+        }
+      }
+    ],
     "stage-0",
+    "stage-2",
     "stage-3"
   ],
-  "plugins": [
-    "transform-flow-strip-types"
-  ]
+  "plugins": ["transform-flow-strip-types"]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+.*/build/.*
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "clubhouse-lib",
   "version": "0.1.7",
   "description": "A Promise based library to the Clubhouse REST API",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "main": "build/index.js",
   "repository": "",
   "license": "MIT",
   "scripts": {
-    "build": "babel src --out-dir build --ignore '**/__tests__/**' && npm run build-flow",
+    "build":
+      "babel src --out-dir build --ignore '**/__tests__/**' && npm run build-flow",
     "build-flow": "flow-copy-source -v -i '**/__tests__/**' src build",
     "lint": "eslint src",
     "prepublish": "npm run build",
@@ -48,7 +47,8 @@
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "<rootDir>/build/",
-      "<rootDir>/node_modules/"
+      "<rootDir>/node_modules/",
+      "(<rootDir>/__tests__/.*|(\\.|/)utils)\\.jsx?$"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     ]
   },
   "dependencies": {
-    "es6-promise": "^4.1.1",
     "fetch-everywhere": "^1.0.5"
   }
 }

--- a/src/FetchRequestParser.js
+++ b/src/FetchRequestParser.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import ClientError from './client_error';
+import type { ResponseParser } from './types';
+
+class FetchRequestParser implements ResponseParser<Response> {
+  // eslint-disable-next-line class-methods-use-this
+  parseResponse = (response: Response): Promise<*> =>
+    response.json().then((json: Object) => {
+      if (response.ok) {
+        return json;
+      }
+
+      return Promise.reject(new ClientError(response, json));
+    });
+}
+
+export default FetchRequestParser;

--- a/src/FetchRequestParser.js
+++ b/src/FetchRequestParser.js
@@ -4,7 +4,6 @@ import ClientError from './client_error';
 import type { ResponseParser } from './types';
 
 class FetchRequestParser implements ResponseParser<Response> {
-  // eslint-disable-next-line class-methods-use-this
   parseResponse = (response: Response): Promise<*> =>
     response.json().then((json: Object) => {
       if (response.ok) {

--- a/src/FetchRequestPerformer.js
+++ b/src/FetchRequestPerformer.js
@@ -2,6 +2,8 @@
 
 import type { RequestPerformer } from './types';
 
+require('fetch-everywhere');
+
 class FetchRequestPerformer implements RequestPerformer<Request, Response> {
   // eslint-disable-next-line class-methods-use-this
   performRequest(request: Request): Promise<Response> {

--- a/src/FetchRequestPerformer.js
+++ b/src/FetchRequestPerformer.js
@@ -5,10 +5,7 @@ import type { RequestPerformer } from './types';
 require('fetch-everywhere');
 
 class FetchRequestPerformer implements RequestPerformer<Request, Response> {
-  // eslint-disable-next-line class-methods-use-this
-  performRequest(request: Request): Promise<Response> {
-    return fetch(request);
-  }
+  performRequest = fetch;
 }
 
 export default FetchRequestPerformer;

--- a/src/FetchRequestPerformer.js
+++ b/src/FetchRequestPerformer.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import type { RequestPerformer } from './types';
+
+class FetchRequestPerformer implements RequestPerformer<Request, Response> {
+  // eslint-disable-next-line class-methods-use-this
+  performRequest(request: Request): Promise<Response> {
+    return fetch(request);
+  }
+}
+
+export default FetchRequestPerformer;

--- a/src/TokenRequestFactory.js
+++ b/src/TokenRequestFactory.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+import type { RequestFactory } from './types';
+
+class TokenRequestFactory implements RequestFactory<Request> {
+  token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  createRequest(url: string, method?: string = 'GET', body?: Object): Request {
+    const urlWithToken = `${url}?token=${this.token}`;
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
+    };
+
+    return new Request(urlWithToken, {
+      body: JSON.stringify(body),
+      headers,
+      method,
+    });
+  }
+}
+
+export default TokenRequestFactory;

--- a/src/__tests__/Client-tests.js
+++ b/src/__tests__/Client-tests.js
@@ -1,30 +1,7 @@
 /* @flow */
 
 import Client from '../index';
-
-class TestFactory {
-  requests: Object[];
-
-  constructor(requests: Object[]) {
-    this.requests = requests;
-  }
-  makeRequest(url: string, method: ?string, body: ?any): Promise<*> {
-    this.requests.push({ url, method, body });
-    return Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve(body),
-    });
-  }
-}
-
-const makeClient = (factory: TestFactory) =>
-  new Client(
-    {
-      baseURL: 'http://localhost:4001',
-      version: 'beta',
-    },
-    factory,
-  );
+import { createTestClient } from './utils';
 
 describe('#Client', () => {
   it('return a new instance with the correct defaults', () => {
@@ -35,7 +12,10 @@ describe('#Client', () => {
   describe('.listProjects', () => {
     it('returns a list of projects with a clubhouse account', async () => {
       const requests = [];
-      const client = makeClient(new TestFactory(requests));
+      const client = createTestClient(request => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: [] });
+      });
 
       await client.listProjects();
 
@@ -46,7 +26,10 @@ describe('#Client', () => {
   describe('.getProject', () => {
     it('requests a single project', async () => {
       const requests = [];
-      const client = makeClient(new TestFactory(requests));
+      const client = createTestClient(request => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: { id: 1234 } });
+      });
 
       await client.getProject(1234);
 
@@ -57,7 +40,10 @@ describe('#Client', () => {
   describe('.createProject', () => {
     it('creates a new project', async () => {
       const requests = [];
-      const client = makeClient(new TestFactory(requests));
+      const client = createTestClient(request => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: { name: 'test' } });
+      });
 
       await client.createProject({ name: 'test' });
 
@@ -68,7 +54,10 @@ describe('#Client', () => {
   describe('.updateProject', () => {
     it('updates a existing project', async () => {
       const requests = [];
-      const client = makeClient(new TestFactory(requests));
+      const client = createTestClient(request => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: { name: 'test' } });
+      });
 
       await client.updateProject(12, { name: 'test' });
 
@@ -79,7 +68,10 @@ describe('#Client', () => {
   describe('.deleteProject', () => {
     it('deletes a existing project', async () => {
       const requests = [];
-      const client = makeClient(new TestFactory(requests));
+      const client = createTestClient(request => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: {} });
+      });
 
       await client.deleteProject(1);
 

--- a/src/__tests__/__snapshots__/Client-tests.js.snap
+++ b/src/__tests__/__snapshots__/Client-tests.js.snap
@@ -7,7 +7,7 @@ Array [
       "name": "test",
     },
     "method": "POST",
-    "url": "http://localhost:4001/api/beta/projects",
+    "uri": "http://localhost:4001/api/beta/projects",
   },
 ]
 `;
@@ -17,7 +17,7 @@ Array [
   Object {
     "body": undefined,
     "method": "DELETE",
-    "url": "http://localhost:4001/api/beta/projects/1",
+    "uri": "http://localhost:4001/api/beta/projects/1",
   },
 ]
 `;
@@ -27,7 +27,7 @@ Array [
   Object {
     "body": undefined,
     "method": undefined,
-    "url": "http://localhost:4001/api/beta/projects/1234",
+    "uri": "http://localhost:4001/api/beta/projects/1234",
   },
 ]
 `;
@@ -37,7 +37,7 @@ Array [
   Object {
     "body": undefined,
     "method": undefined,
-    "url": "http://localhost:4001/api/beta/projects",
+    "uri": "http://localhost:4001/api/beta/projects",
   },
 ]
 `;
@@ -49,7 +49,7 @@ Array [
       "name": "test",
     },
     "method": "PUT",
-    "url": "http://localhost:4001/api/beta/projects/12",
+    "uri": "http://localhost:4001/api/beta/projects/12",
   },
 ]
 `;

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -29,6 +29,8 @@ export class TestRequestFactory implements RequestFactory<TestRequest> {
   });
 }
 
+type PromiseResolver<Input, Output> = Input => Promise<Output>;
+
 export class TestRequestPerformer
   implements RequestPerformer<TestRequest, TestResponse> {
   static resolve = (request: TestRequest, response: TestResponse) =>
@@ -37,11 +39,11 @@ export class TestRequestPerformer
   static reject = (request: TestRequest, response: TestResponse) =>
     new TestRequestPerformer(() => Promise.reject(response));
 
-  constructor(resolver: (request: TestRequest) => Promise<TestResponse>) {
+  constructor(resolver: PromiseResolver<TestRequest, TestResponse>) {
     this.resolver = resolver;
   }
 
-  resolver: (request: TestRequest) => Promise<TestResponse>;
+  resolver: PromiseResolver<TestRequest, TestResponse>;
 
   performRequest = (request: TestRequest): Promise<TestResponse> =>
     this.resolver(request);
@@ -54,11 +56,11 @@ export class TestResponseParser implements ResponseParser<TestResponse> {
   static reject = (response: TestResponse, result: *) =>
     new TestRequestPerformer(() => Promise.reject(result));
 
-  constructor(resolver: (response: TestResponse) => Promise<*>) {
+  constructor(resolver: PromiseResolver<TestResponse, *>) {
     this.resolver = resolver;
   }
 
-  resolver: (response: TestResponse) => Promise<*>;
+  resolver: PromiseResolver<TestResponse, *>;
 
   parseResponse = (response: TestResponse): Promise<*> =>
     this.resolver(response);

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,0 +1,82 @@
+/* @flow */
+
+import Client from '../index';
+
+import type {
+  RequestFactory,
+  RequestPerformer,
+  ResponseParser,
+} from '../types';
+
+type TestRequest = {
+  uri: string,
+  method?: string,
+  body?: Object,
+};
+
+type JSON = Object | Array<JSON> | number | string;
+
+type TestResponse = {
+  status: number,
+  body?: JSON,
+};
+
+export class TestRequestFactory implements RequestFactory<TestRequest> {
+  createRequest = (uri: string, method?: string, body?: Object) => ({
+    uri,
+    method,
+    body,
+  });
+}
+
+export class TestRequestPerformer
+  implements RequestPerformer<TestRequest, TestResponse> {
+  static resolve = (request: TestRequest, response: TestResponse) =>
+    new TestRequestPerformer(() => Promise.resolve(response));
+
+  static reject = (request: TestRequest, response: TestResponse) =>
+    new TestRequestPerformer(() => Promise.reject(response));
+
+  constructor(resolver: (request: TestRequest) => Promise<TestResponse>) {
+    this.resolver = resolver;
+  }
+
+  resolver: (request: TestRequest) => Promise<TestResponse>;
+
+  performRequest = (request: TestRequest): Promise<TestResponse> =>
+    this.resolver(request);
+}
+
+export class TestResponseParser implements ResponseParser<TestResponse> {
+  static resolve = (response: TestResponse, result: *) =>
+    new TestRequestPerformer(() => Promise.resolve(result));
+
+  static reject = (response: TestResponse, result: *) =>
+    new TestRequestPerformer(() => Promise.reject(result));
+
+  constructor(resolver: (response: TestResponse) => Promise<*>) {
+    this.resolver = resolver;
+  }
+
+  resolver: (response: TestResponse) => Promise<*>;
+
+  parseResponse = (response: TestResponse): Promise<*> =>
+    this.resolver(response);
+}
+
+export const createTestClient = (
+  requestPerformer: (request: TestRequest) => Promise<TestResponse>,
+  responseParser: (response: TestResponse) => Promise<*> = response =>
+    Promise.resolve(response),
+) =>
+  new Client(
+    {
+      baseURL: 'http://localhost:4001',
+      version: 'beta',
+    },
+    new TestRequestFactory(),
+    new TestRequestPerformer(requestPerformer),
+    new TestResponseParser(responseParser),
+  );
+
+export default createTestClient;

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -14,7 +14,15 @@ type TestRequest = {
   body?: Object,
 };
 
-type JSON = Object | Array<JSON> | number | string;
+// As per ECMA-404 spec: http://www.json.org/
+// and RFC-7159 spec: https://tools.ietf.org/html/rfc7159
+type JSON =
+  | { [keys: string]: JSON }
+  | Array<JSON>
+  | string
+  | number
+  | boolean
+  | null;
 
 type TestResponse = {
   status: number,

--- a/src/index.js
+++ b/src/index.js
@@ -45,19 +45,19 @@ const defaultConfig = {
 /**
  * @class Client
 */
-class Client<T, U> {
+class Client<RequestType, ResponseType> {
   baseURL: string;
   version: string;
 
-  requestFactory: RequestFactory<T>;
-  requestPerformer: RequestPerformer<T, U>;
-  responseParser: ResponseParser<U>;
+  requestFactory: RequestFactory<RequestType>;
+  requestPerformer: RequestPerformer<RequestType, ResponseType>;
+  responseParser: ResponseParser<ResponseType>;
 
   constructor(
     { baseURL, version }: ClientConfig = defaultConfig,
-    requestFactory: RequestFactory<T>,
-    requestPerformer: RequestPerformer<T, U>,
-    responseParser: ResponseParser<U>,
+    requestFactory: RequestFactory<RequestType>,
+    requestPerformer: RequestPerformer<RequestType, ResponseType>,
+    responseParser: ResponseParser<ResponseType>,
   ) {
     this.baseURL = baseURL;
     this.version = version;
@@ -82,7 +82,7 @@ class Client<T, U> {
     return `${this.baseURL}/api/${this.version}/${uri}`;
   }
 
-  listResource<ResponseType>(uri: string): Promise<Array<ResponseType>> {
+  listResource<T>(uri: string): Promise<Array<T>> {
     const URL = this.generateUrl(uri);
     const request = this.requestFactory.createRequest(URL);
     return this.requestPerformer
@@ -90,7 +90,7 @@ class Client<T, U> {
       .then(this.responseParser.parseResponse);
   }
 
-  getResource<ResponseType>(uri: string): Promise<ResponseType> {
+  getResource<T>(uri: string): Promise<T> {
     const URL = this.generateUrl(uri);
     const request = this.requestFactory.createRequest(URL);
     return this.requestPerformer
@@ -98,10 +98,7 @@ class Client<T, U> {
       .then(this.responseParser.parseResponse);
   }
 
-  createResource<ResponseType>(
-    uri: string,
-    params: Object,
-  ): Promise<ResponseType> {
+  createResource<T>(uri: string, params: Object): Promise<T> {
     const URL = this.generateUrl(uri);
     const request = this.requestFactory.createRequest(URL, 'POST', params);
     return this.requestPerformer
@@ -109,10 +106,7 @@ class Client<T, U> {
       .then(this.responseParser.parseResponse);
   }
 
-  updateResource<ResponseType>(
-    uri: string,
-    params: Object,
-  ): Promise<ResponseType> {
+  updateResource<T>(uri: string, params: Object): Promise<T> {
     const URL = this.generateUrl(uri);
     const request = this.requestFactory.createRequest(URL, 'PUT', params);
     return this.requestPerformer
@@ -120,7 +114,7 @@ class Client<T, U> {
       .then(this.responseParser.parseResponse);
   }
 
-  deleteResource<ResponseType>(uri: string): Promise<ResponseType> {
+  deleteResource<T>(uri: string): Promise<T> {
     const URL = this.generateUrl(uri);
     const request = this.requestFactory.createRequest(URL, 'DELETE');
     return this.requestPerformer

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ import type {
 } from './types';
 
 require('es6-promise').polyfill();
-require('fetch-everywhere');
 
 const API_BASE_URL: string = 'https://api.clubhouse.io';
 const API_VERSION: string = 'beta';

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,6 @@ import type {
   ID,
 } from './types';
 
-require('es6-promise').polyfill();
-
 const API_BASE_URL: string = 'https://api.clubhouse.io';
 const API_VERSION: string = 'beta';
 

--- a/src/types.js
+++ b/src/types.js
@@ -8,8 +8,16 @@ export interface Entity {
   updated_at: string;
 }
 
-export interface RequestFactory {
-  makeRequest(uri: string, method?: string, body?: Object): Promise<*>;
+export interface RequestFactory<T> {
+  createRequest(uri: string, method?: string, body?: Object): T;
+}
+
+export interface RequestPerformer<T, U> {
+  performRequest(request: T): Promise<U>;
+}
+
+export interface ResponseParser<U> {
+  parseResponse(response: U): Promise<*>;
 }
 
 /* Users */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,10 +1791,6 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es6-promise@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
This allows for different implementations of this library to use whatever network client they prefer, rather than tying a user down to using the fetch polyfill and it's implementation details. Specifically, we assumed before that all `RequestPerformer`s would return a `Response` type object. However, some networking libraries return their own types instead.

By generalizing this concept, different networking libraries can return their own types, as long as they return the appropriate shaped JSON types in the end. This removes the implementation details of `fetch` and `Response`.

This opens users up to use `fetch`, `fetch` polyfills, `XMLHttpRequest`, `axios` or whatever networking library is the flavor of the week.

⚠️ Note that this a fairly substantial change that doesn't break consumers of `Client.create`, but will break for all consumers who use their own `RequestFactory`s in the constructor, so as such, this warrants a semver breaking change.
