### PR TITLE
Add team resources and API methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,27 +5,28 @@ import FetchRequestPerformer from './FetchRequestPerformer';
 import FetchRequestParser from './FetchRequestParser';
 
 import type {
-  Project,
-  ProjectChange,
-  Story,
-  StoryChange,
-  Member,
   Epic,
   EpicChange,
-  StoryComment,
-  Task,
-  TaskChange,
-  Workflow,
-  StoryLinkChange,
-  StoryLink,
   File,
   FileChange,
+  ID,
   LinkedFile,
   LinkedFileChange,
+  Member,
+  Project,
+  ProjectChange,
   RequestFactory,
   RequestPerformer,
   ResponseParser,
-  ID,
+  Story,
+  StoryChange,
+  StoryComment,
+  StoryLink,
+  StoryLinkChange,
+  Task,
+  TaskChange,
+  Team,
+  Workflow,
 } from './types';
 
 const API_BASE_URL: string = 'https://api.clubhouse.io';
@@ -298,6 +299,16 @@ class Client<RequestType, ResponseType> {
   /** */
   deleteLinkedFile(linkedFileID: ID): Promise<{}> {
     return this.deleteResource(`linked-files/${linkedFileID}`);
+  }
+
+  /** */
+  listTeams(): Promise<Array<Team>> {
+    return this.listResource('teams');
+  }
+
+  /** */
+  getTeam(teamID: ID): Promise<Team> {
+    return this.getResource(`teams/${teamID}`);
   }
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -328,3 +328,16 @@ export type Fact = {
   at: string,
   scope: string,
 };
+
+/* Teams */
+
+export type Team = {
+  created_at: string,
+  description: string,
+  id: ID,
+  name: string,
+  position: number,
+  project_ids: Array<ID>,
+  updated_at: string,
+  workflow: Workflow,
+};


### PR DESCRIPTION
This adds the new Team entities into the library, allowing for listing
teams and viewing a specific team.

More information about Teams can be found here: https://clubhouse.io/api/rest/v2/#Teams