### PR TITLE
Catch response parsing errors as ClientError

### DIFF
--- a/src/FetchRequestParser.js
+++ b/src/FetchRequestParser.js
@@ -4,17 +4,17 @@ import ClientError from './client_error';
 import type { ResponseParser } from './types';
 
 class FetchRequestParser implements ResponseParser<Response> {
-    parseResponse = (response: Response): Promise<*> =>
-        response
-            .json()
-            .then((json: Object) => {
-                if (response.ok) {
-                    return json;
-                }
+  parseResponse = (response: Response): Promise<*> =>
+    response
+      .json()
+      .then((json: Object) => {
+        if (response.ok) {
+          return json;
+        }
 
-                return Promise.reject(new ClientError(response, json));
-            })
-            .catch(() => Promise.reject(new ClientError(response, {})));
+        return Promise.reject(new ClientError(response, json));
+      })
+      .catch(() => Promise.reject(new ClientError(response, {})));
 }
 
 export default FetchRequestParser;

--- a/src/FetchRequestParser.js
+++ b/src/FetchRequestParser.js
@@ -11,6 +11,8 @@ class FetchRequestParser implements ResponseParser<Response> {
       }
 
       return Promise.reject(new ClientError(response, json));
+    }).catch(() => {
+      return Promise.reject(new ClientError(response));
     });
 }
 

--- a/src/FetchRequestParser.js
+++ b/src/FetchRequestParser.js
@@ -4,16 +4,17 @@ import ClientError from './client_error';
 import type { ResponseParser } from './types';
 
 class FetchRequestParser implements ResponseParser<Response> {
-  parseResponse = (response: Response): Promise<*> =>
-    response.json().then((json: Object) => {
-      if (response.ok) {
-        return json;
-      }
+    parseResponse = (response: Response): Promise<*> =>
+        response
+            .json()
+            .then((json: Object) => {
+                if (response.ok) {
+                    return json;
+                }
 
-      return Promise.reject(new ClientError(response, json));
-    }).catch(() => {
-      return Promise.reject(new ClientError(response));
-    });
+                return Promise.reject(new ClientError(response, json));
+            })
+            .catch(() => Promise.reject(new ClientError(response, {})));
 }
 
 export default FetchRequestParser;


### PR DESCRIPTION
Right now, the API has gateway timeout issues. When the request times out, the response is not parseable JSON, so the error thrown by the client is related to the parsing, not to the actual response.

This helps in transparency by throwing a consistent ClientError with an attached response for debugging.