### PR TITLE
Properly handle query params alongside request bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     ]
   },
   "dependencies": {
-    "fetch-everywhere": "^1.0.5"
+    "fetch-everywhere": "^1.0.5",
+    "query-string": "^6.2.0"
   }
 }

--- a/src/TokenRequestFactory.js
+++ b/src/TokenRequestFactory.js
@@ -1,6 +1,10 @@
 /* @flow */
 
+import { stringify } from 'query-string';
+
 import type { RequestFactory } from './types';
+
+require('fetch-everywhere');
 
 class TokenRequestFactory implements RequestFactory<Request> {
   token: string;
@@ -10,14 +14,25 @@ class TokenRequestFactory implements RequestFactory<Request> {
   }
 
   createRequest(url: string, method?: string = 'GET', body?: Object): Request {
-    const urlWithToken = `${url}?token=${this.token}`;
     const headers = {
       Accept: 'application/json',
       'Content-Type': 'application/json; charset=utf-8',
     };
+    const params = {
+      ...body,
+      token: this.token,
+    };
 
-    return new Request(urlWithToken, {
-      body: JSON.stringify(body),
+    if (method === 'GET') {
+      const resolvedURL = `${url}?${stringify(params)}`;
+      return new Request(resolvedURL, {
+        headers,
+        method,
+      });
+    }
+
+    return new Request(url, {
+      body: JSON.stringify(params),
       headers,
       method,
     });

--- a/src/__tests__/TokenRequestFactory-tests.js
+++ b/src/__tests__/TokenRequestFactory-tests.js
@@ -4,12 +4,39 @@ import TokenRequestFactory from '../TokenRequestFactory';
 
 require('fetch-everywhere');
 
-describe('#TokenRequestFactory', () => {
-  it('correctly combines query parameters', () => {
-    const factory = new TokenRequestFactory('abc-123');
-    const request = factory.createRequest('search/stories', 'GET', {
-      query: 'project:mobile',
+describe('TokenRequestFactory', () => {
+  describe('GET Requests', () => {
+    it('correctly combines query parameters', () => {
+      const factory = new TokenRequestFactory('abc-123');
+      const request = factory.createRequest(
+        'https://api.clubhouse.io/beta/search/stories',
+        'GET',
+        {
+          query: 'project:mobile',
+        },
+      );
+      expect(request.url).toEqual('https://api.clubhouse.io/beta/search/stories?query=project%3Amobile&token=abc-123');
+      // $FlowFixMe
+      expect(request.body).toBeUndefined();
     });
-    expect(request.url).toEqual('search/stories?token=abc-123&query=project:mobile');
+  });
+
+  describe('POST/PUT Requests', () => {
+    it('correctly combines query parameters', () => {
+      const factory = new TokenRequestFactory('abc-123');
+      const request = factory.createRequest(
+        'https://api.clubhouse.io/beta/search/stories',
+        'POST',
+        {
+          query: 'project:mobile',
+        },
+      );
+      expect(request.url).toEqual('https://api.clubhouse.io/beta/search/stories');
+      // $FlowFixMe
+      expect(JSON.parse(request.body)).toEqual({
+        query: 'project:mobile',
+        token: 'abc-123',
+      });
+    });
   });
 });

--- a/src/__tests__/TokenRequestFactory-tests.js
+++ b/src/__tests__/TokenRequestFactory-tests.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import TokenRequestFactory from '../TokenRequestFactory';
+
+require('fetch-everywhere');
+
+describe('#TokenRequestFactory', () => {
+  it('correctly combines query parameters', () => {
+    const factory = new TokenRequestFactory('abc-123');
+    const request = factory.createRequest('search/stories', 'GET', {
+      query: 'project:mobile',
+    });
+    expect(request.url).toEqual('search/stories?token=abc-123&query=project:mobile');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,6 +1911,11 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -4231,6 +4236,14 @@ qs@~6.4.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
   integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -4734,6 +4747,11 @@ stream-combiner@~0.0.4:
   integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
   dependencies:
     duplexer "~0.1.1"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This varies behavior for GET requests versus all other requests, where parameters
for GET requests should be in the query string, whereas other methods should use
the body.

This adds in the [`query-string`](https://www.npmjs.com/package/query-string) module to help us create these queries.

Fixes #29 