### PR TITLE
Add support for searchStories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import type {
   StoryComment,
   StoryLink,
   StoryLinkChange,
+  StorySearchResult,
   Task,
   TaskChange,
   Team,
@@ -178,6 +179,20 @@ class Client<RequestType, ResponseType> {
   /** */
   listStories(projectID: ID): Promise<Array<Story>> {
     return this.listResource(`projects/${projectID}/stories`);
+  }
+
+  /** */
+  searchStories(
+    query: String,
+    pageSize: number = 25,
+  ): Promise<StorySearchResult> {
+    return this.getResource(`search/stories`, {
+      query,
+      page_size: pageSize,
+    }).then(result => ({
+      ...result,
+      fetchNext: () => this.getResource(result.next),
+    }));
   }
 
   /** */

--- a/src/types.js
+++ b/src/types.js
@@ -150,6 +150,11 @@ export type StoryChange = {
   linked_file_ids?: Array<ID>,
 };
 
+export type StorySearchResult = {
+  data: Array<Story>,
+  fetchNext: () => Promise<StorySearchResult>,
+};
+
 /* Epic */
 
 export type EpicStates = 'to do' | 'in progress' | 'done';


### PR DESCRIPTION
Usage `client.searchStories('owner:your-username').then(...)`

I am not sure if it's the most elegant implementation.