### PR TITLE
Add support for explicit API path

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "fetch-everywhere": "^1.0.5",
-    "query-string": "^6.2.0"
+    "query-string": "^6.2.0",
+    "universal-url": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepublish": "npm run build",
     "test": "jest",
     "flow": "flow",
+    "prettier": "prettier --single-quote --trailing-comma all --write src/**/*.js",
     "ci": "npm run lint && npm run flow && npm test"
   },
   "devDependencies": {
@@ -41,7 +42,7 @@
     "flow-bin": "^0.55.0",
     "flow-copy-source": "^1.2.1",
     "jest": "^21.2.0",
-    "prettier": "^1.7.1",
+    "prettier": "^1.16.4",
     "save": "^2.3.1"
   },
   "jest": {

--- a/src/TokenRequestFactory.js
+++ b/src/TokenRequestFactory.js
@@ -1,38 +1,52 @@
 /* @flow */
 
-import { stringify } from 'query-string';
-
+import { URL } from 'universal-url';
 import type { RequestFactory } from './types';
 
 require('fetch-everywhere');
 
 class TokenRequestFactory implements RequestFactory<Request> {
   token: string;
+  baseURL: string;
+  version: string;
 
-  constructor(token: string) {
+  constructor(token: string, baseURL: string, version: string) {
     this.token = token;
+    this.baseURL = baseURL;
+    this.version = version;
   }
 
-  createRequest(url: string, method?: string = 'GET', body?: Object): Request {
+  prefixURI(uri: string): string {
+    const prefix = `/api/${this.version}/`;
+    if (uri.startsWith(prefix)) {
+      return uri;
+    }
+    return `${prefix}${uri}`;
+  }
+
+  createRequest(uri: string, method?: string = 'GET', body?: Object): Request {
+    const url = new URL(this.prefixURI(uri), this.baseURL);
     const headers = {
       Accept: 'application/json',
       'Content-Type': 'application/json; charset=utf-8',
     };
-    const params = {
-      ...body,
-      token: this.token,
-    };
+
+    url.searchParams.append('token', this.token);
 
     if (method === 'GET') {
-      const resolvedURL = `${url}?${stringify(params)}`;
-      return new Request(resolvedURL, {
+      if (body) {
+        Object.entries(body).forEach(entry =>
+          url.searchParams.append(entry[0], String(entry[1])),
+        );
+      }
+      return new Request(url.toString(), {
         headers,
         method,
       });
     }
 
-    return new Request(url, {
-      body: JSON.stringify(params),
+    return new Request(url.toString(), {
+      body: JSON.stringify(body),
       headers,
       method,
     });

--- a/src/__tests__/Client-tests.js
+++ b/src/__tests__/Client-tests.js
@@ -6,7 +6,7 @@ import { createTestClient } from './utils';
 describe('#Client', () => {
   it('return a new instance with the correct defaults', () => {
     const client = Client.create('token value');
-    expect(client.version).toBe('beta');
+    expect(client.requestFactory.version).toBe('beta');
   });
 
   describe('.listProjects', () => {

--- a/src/__tests__/TokenRequestFactory-tests.js
+++ b/src/__tests__/TokenRequestFactory-tests.js
@@ -15,7 +15,10 @@ describe('TokenRequestFactory', () => {
           query: 'project:mobile',
         },
       );
-      expect(request.url).toEqual('https://api.clubhouse.io/beta/search/stories?query=project%3Amobile&token=abc-123');
+
+      expect(request.url).toEqual(
+        'https://api.clubhouse.io/beta/search/stories?query=project%3Amobile&token=abc-123',
+      );
       // $FlowFixMe
       expect(request.body).toBeUndefined();
     });
@@ -31,7 +34,9 @@ describe('TokenRequestFactory', () => {
           query: 'project:mobile',
         },
       );
-      expect(request.url).toEqual('https://api.clubhouse.io/beta/search/stories');
+      expect(request.url).toEqual(
+        'https://api.clubhouse.io/beta/search/stories',
+      );
       // $FlowFixMe
       expect(JSON.parse(request.body)).toEqual({
         query: 'project:mobile',

--- a/src/__tests__/TokenRequestFactory-tests.js
+++ b/src/__tests__/TokenRequestFactory-tests.js
@@ -7,17 +7,17 @@ require('fetch-everywhere');
 describe('TokenRequestFactory', () => {
   describe('GET Requests', () => {
     it('correctly combines query parameters', () => {
-      const factory = new TokenRequestFactory('abc-123');
-      const request = factory.createRequest(
-        'https://api.clubhouse.io/beta/search/stories',
-        'GET',
-        {
-          query: 'project:mobile',
-        },
+      const factory = new TokenRequestFactory(
+        'abc-123',
+        'https://api.clubhouse.io',
+        'beta',
       );
+      const request = factory.createRequest('search/stories', 'GET', {
+        query: 'project:mobile',
+      });
 
       expect(request.url).toEqual(
-        'https://api.clubhouse.io/beta/search/stories?query=project%3Amobile&token=abc-123',
+        'https://api.clubhouse.io/api/beta/search/stories?token=abc-123&query=project%3Amobile',
       );
       // $FlowFixMe
       expect(request.body).toBeUndefined();
@@ -26,21 +26,20 @@ describe('TokenRequestFactory', () => {
 
   describe('POST/PUT Requests', () => {
     it('correctly combines query parameters', () => {
-      const factory = new TokenRequestFactory('abc-123');
-      const request = factory.createRequest(
-        'https://api.clubhouse.io/beta/search/stories',
-        'POST',
-        {
-          query: 'project:mobile',
-        },
+      const factory = new TokenRequestFactory(
+        'abc-123',
+        'https://api.clubhouse.io',
+        'beta',
       );
+      const request = factory.createRequest('search/stories', 'POST', {
+        query: 'project:mobile',
+      });
       expect(request.url).toEqual(
-        'https://api.clubhouse.io/beta/search/stories',
+        'https://api.clubhouse.io/api/beta/search/stories?token=abc-123',
       );
       // $FlowFixMe
       expect(JSON.parse(request.body)).toEqual({
         query: 'project:mobile',
-        token: 'abc-123',
       });
     });
   });

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -30,8 +30,15 @@ type TestResponse = {
 };
 
 export class TestRequestFactory implements RequestFactory<TestRequest> {
+  baseURL: string = 'http://localhost:4001';
+  version: string = 'beta';
+
+  prefixURI(uri: string) {
+    return `${this.baseURL}/api/${this.version}/${uri}`;
+  }
+
   createRequest = (uri: string, method?: string, body?: Object) => ({
-    uri,
+    uri: this.prefixURI(uri),
     method,
     body,
   });
@@ -80,10 +87,6 @@ export const createTestClient = (
     Promise.resolve(response),
 ) =>
   new Client(
-    {
-      baseURL: 'http://localhost:4001',
-      version: 'beta',
-    },
     new TestRequestFactory(),
     new TestRequestPerformer(requestPerformer),
     new TestResponseParser(responseParser),

--- a/src/index.js
+++ b/src/index.js
@@ -45,23 +45,17 @@ const defaultConfig = {
 
 /**
  * @class Client
-*/
+ */
 class Client<RequestType, ResponseType> {
-  baseURL: string;
-  version: string;
-
   requestFactory: RequestFactory<RequestType>;
   requestPerformer: RequestPerformer<RequestType, ResponseType>;
   responseParser: ResponseParser<ResponseType>;
 
   constructor(
-    { baseURL, version }: ClientConfig = defaultConfig,
     requestFactory: RequestFactory<RequestType>,
     requestPerformer: RequestPerformer<RequestType, ResponseType>,
     responseParser: ResponseParser<ResponseType>,
   ) {
-    this.baseURL = baseURL;
-    this.version = version;
     this.requestFactory = requestFactory;
     this.requestPerformer = requestPerformer;
     this.responseParser = responseParser;
@@ -69,57 +63,48 @@ class Client<RequestType, ResponseType> {
   /** */
   static create(
     token: string,
-    options: ?ClientConfig,
+    config?: ClientConfig = defaultConfig,
   ): Client<Request, Response> {
+    const { baseURL, version } = config;
     return new Client(
-      options || defaultConfig,
-      new TokenRequestFactory(token),
+      new TokenRequestFactory(token, baseURL, version),
       new FetchRequestPerformer(),
       new FetchRequestParser(),
     );
   }
 
-  generateUrl(uri: string): string {
-    return `${this.baseURL}/api/${this.version}/${uri}`;
-  }
-
   listResource<T>(uri: string): Promise<Array<T>> {
-    const URL = this.generateUrl(uri);
-    const request = this.requestFactory.createRequest(URL);
+    const request = this.requestFactory.createRequest(uri);
     return this.requestPerformer
       .performRequest(request)
       .then(this.responseParser.parseResponse);
   }
 
   getResource<T>(uri: string, params: ?Object): Promise<T> {
-    const URL = this.generateUrl(uri);
     const request = params
-      ? this.requestFactory.createRequest(URL, 'GET', params)
-      : this.requestFactory.createRequest(URL);
+      ? this.requestFactory.createRequest(uri, 'GET', params)
+      : this.requestFactory.createRequest(uri);
     return this.requestPerformer
       .performRequest(request)
       .then(this.responseParser.parseResponse);
   }
 
   createResource<T>(uri: string, params: Object): Promise<T> {
-    const URL = this.generateUrl(uri);
-    const request = this.requestFactory.createRequest(URL, 'POST', params);
+    const request = this.requestFactory.createRequest(uri, 'POST', params);
     return this.requestPerformer
       .performRequest(request)
       .then(this.responseParser.parseResponse);
   }
 
   updateResource<T>(uri: string, params: Object): Promise<T> {
-    const URL = this.generateUrl(uri);
-    const request = this.requestFactory.createRequest(URL, 'PUT', params);
+    const request = this.requestFactory.createRequest(uri, 'PUT', params);
     return this.requestPerformer
       .performRequest(request)
       .then(this.responseParser.parseResponse);
   }
 
   deleteResource<T>(uri: string, params?: Object): Promise<T> {
-    const URL = this.generateUrl(uri);
-    const request = this.requestFactory.createRequest(URL, 'DELETE', params);
+    const request = this.requestFactory.createRequest(uri, 'DELETE', params);
     return this.requestPerformer
       .performRequest(request)
       .then(this.responseParser.parseResponse);

--- a/src/types.js
+++ b/src/types.js
@@ -9,7 +9,10 @@ export interface Entity {
 }
 
 export interface RequestFactory<T> {
+  baseURL: string;
+  version: string;
   createRequest(uri: string, method?: string, body?: Object): T;
+  prefixURI(uri: string): string;
 }
 
 export interface RequestPerformer<T, U> {


### PR DESCRIPTION
The search endpoint returns an absolute path. The previous version would
prefix `/api/beta` which would break the next URL.

As discussed in clubhouse #31
