### PR TITLE
search, return fetchNext if there is next

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,13 +186,20 @@ class Client<RequestType, ResponseType> {
     query: String,
     pageSize: number = 25,
   ): Promise<StorySearchResult> {
+    const processResult = result => {
+      if (result.next) {
+        return {
+          ...result,
+          fetchNext: () => this.getResource(result.next).then(processResult),
+        };
+      }
+      return result;
+    };
+
     return this.getResource(`search/stories`, {
       query,
       page_size: pageSize,
-    }).then(result => ({
-      ...result,
-      fetchNext: () => this.getResource(result.next),
-    }));
+    }).then(processResult);
   }
 
   /** */


### PR DESCRIPTION
The issue was that the result of invoking `fetchNext()` would not add a `fetchNext()` even if there is a next url.

Long story short, when I was testing #31, the client was implementing the same logic and ignore `fetchNext()`

Usage example:

```js
const searchStories = async (program) => new Promise((resolve, reject) => {
    let stories = [];

    const processResult = result => {
        stories = stories.concat(result.data);
        if (!result.fetchNext) {
            return resolve(stories);
        }
        result.fetchNext()
            .then(processResult)
            .catch(reject);
    };

    client.searchStories(program.args.join(' '))
        .then(processResult)
        .catch(reject);
});

``` 
