### PR TITLE
fix: update correct import documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install --save clubhouse-lib
 ## Usage
 
 ```javascript
-import Clubhouse from 'clubhouse-lib';
+import * as Clubhouse from 'clubhouse-lib';
 
 const client = Clubhouse.create('your token value');
 


### PR DESCRIPTION
First off, thanks for having an SDK! I find it awesome that you guys allow your API to be extensible by other developers 😄.

This pr address the documentation for importing the clubhouse sdk in the readme.

When working with the sdk, I noticed that the current documented way of importing clubhouse is incorrect.

However, what did work were the following:

```ts
import * as Clubhouse from 'clubhouse-lib';

const client = Clubhouse.create("...");
```

and

```ts
import { create } from 'clubhouse-lib';

const client = create("...");
```

Personally, I prefer the first option since it avoids conflict with the popular method name `create` 😀 but that's up to y'all. 

Another way to implement this is to have a constructor for the client class. 
In this case, creating a new client would look like the following:

```ts
import { Client } from 'clubhouse-lib';

const client = new Client("...");
```