### PR TITLE
Add iteration_id to Story typing, remove storyID from Iteration calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ import type {
   Team,
   Workflow,
   Iteration,
-  IterationStats,
   IterationChange,
 } from './types';
 
@@ -336,10 +335,10 @@ class Client<RequestType, ResponseType> {
 
   /** */
   updateIteration(
-      storyID: ID,
-      iterationID: ID,
-      params: IterationChange
-    ): Promise<Iteration> {
+    storyID: ID,
+    iterationID: ID,
+    params: IterationChange
+  ): Promise<Iteration> {
     return this.updateResource(`iterations/${iterationID}`, params);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ class Client<RequestType, ResponseType> {
   updateIteration(
     storyID: ID,
     iterationID: ID,
-    params: IterationChange
+    params: IterationChange,
   ): Promise<Iteration> {
     return this.updateResource(`iterations/${iterationID}`, params);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -335,7 +335,11 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  updateIteration(storyID: ID, iterationID: ID, params: IterationChange): Promise<Iteration> {
+  updateIteration(
+      storyID: ID,
+      iterationID: ID,
+      params: IterationChange
+    ): Promise<Iteration> {
     return this.updateResource(`iterations/${iterationID}`, params);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ import type {
   TaskChange,
   Team,
   Workflow,
+  Iteration,
+  IterationStats,
+  IterationChange,
 } from './types';
 
 const API_BASE_URL: string = 'https://api.clubhouse.io';
@@ -314,6 +317,31 @@ class Client<RequestType, ResponseType> {
   /** */
   getTeam(teamID: ID): Promise<Team> {
     return this.getResource(`teams/${teamID}`);
+  }
+
+  /** */
+  listIterations(): Promise<Array<Iteration>> {
+    return this.listResource(`iterations`);
+  }
+
+  /** */
+  createIteration(storyID: ID, params: IterationChange): Promise<Iteration> {
+    return this.createResource(`iterations`, params);
+  }
+
+  /** */
+  getIteration(storyID: ID, iterationID: ID): Promise<Iteration> {
+    return this.getResource(`iterations/${iterationID}`);
+  }
+
+  /** */
+  updateIteration(storyID: ID, iterationID: ID, params: IterationChange): Promise<Iteration> {
+    return this.updateResource(`iterations/${iterationID}`, params);
+  }
+
+  /** */
+  deleteIteration(storyID: ID, iterationID: ID): Promise<{}> {
+    return this.deleteResource(`iterations/${iterationID}`);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -324,18 +324,17 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  createIteration(storyID: ID, params: IterationChange): Promise<Iteration> {
+  createIteration(params: IterationChange): Promise<Iteration> {
     return this.createResource(`iterations`, params);
   }
 
   /** */
-  getIteration(storyID: ID, iterationID: ID): Promise<Iteration> {
+  getIteration(iterationID: ID): Promise<Iteration> {
     return this.getResource(`iterations/${iterationID}`);
   }
 
   /** */
   updateIteration(
-    storyID: ID,
     iterationID: ID,
     params: IterationChange,
   ): Promise<Iteration> {
@@ -343,7 +342,7 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  deleteIteration(storyID: ID, iterationID: ID): Promise<{}> {
+  deleteIteration(iterationID: ID): Promise<{}> {
     return this.deleteResource(`iterations/${iterationID}`);
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -384,6 +384,20 @@ export type Team = {
 };
 
 /* Iterations */
+
+export type IterationStats = {
+  average_cycle_time: number,
+  average_lead_time: number,
+  num_points: number,
+  num_points_done: number,
+  num_points_started: number,
+  num_points_unstarted: number,
+  num_stories_done: number,
+  num_stories_started: number,
+  num_stories_unestimated: number,
+  num_stories_unstarted: number,
+};
+
 export type Iteration = {
   created_at: string,
   updated_at: string,
@@ -397,19 +411,6 @@ export type Iteration = {
   follower_ids: Array<ID>,
   mention_ids: Array<ID>,
   stats: IterationStats,
-};
-
-export type IterationStats = {
-  average_cycle_time: number,
-  average_lead_time: number,
-  num_points: number,
-  num_points_done: number,
-  num_points_started: number,
-  num_points_unstarted: number,
-  num_stories_done: number,
-  num_stories_started: number,
-  num_stories_unestimated: number,
-  num_stories_unstarted: number
 };
 
 export type IterationChange = {

--- a/src/types.js
+++ b/src/types.js
@@ -382,3 +382,40 @@ export type Team = {
   updated_at: string,
   workflow: Workflow,
 };
+
+/* Iterations */
+export type Iteration = {
+  created_at: string,
+  updated_at: string,
+  start_date: string,
+  end_date: string,
+  description: string,
+  id: ID,
+  name: string,
+  entity_type: string,
+  status: string,
+  follower_ids: Array<ID>,
+  mention_ids: Array<ID>,
+  stats: IterationStats,
+};
+
+export type IterationStats = {
+  average_cycle_time: number,
+  average_lead_time: number,
+  num_points: number,
+  num_points_done: number,
+  num_points_started: number,
+  num_points_unstarted: number,
+  num_stories_done: number,
+  num_stories_started: number,
+  num_stories_unestimated: number,
+  num_stories_unstarted: number
+};
+
+export type IterationChange = {
+  name?: string,
+  description?: string,
+  start_date?: string,
+  end_date?: string,
+  follower_ids?: Array<ID>,
+};

--- a/src/types.js
+++ b/src/types.js
@@ -398,6 +398,8 @@ export type IterationStats = {
   num_stories_unstarted: number,
 };
 
+export type IterationStatus = 'unstarted' | 'started' | 'done';
+
 export type Iteration = {
   created_at: string,
   updated_at: string,
@@ -407,7 +409,7 @@ export type Iteration = {
   id: ID,
   name: string,
   entity_type: string,
-  status: string,
+  status: IterationStatus,
   follower_ids: Array<ID>,
   mention_ids: Array<ID>,
   stats: IterationStats,

--- a/src/types.js
+++ b/src/types.js
@@ -230,6 +230,7 @@ export type Story = {
   owner_ids: Array<ID>,
   follower_ids: Array<ID>,
   epic_id: ID,
+  iteration_id: ID,
   tasks_id: Array<ID>,
   app_url: string,
 };
@@ -249,6 +250,7 @@ export type StoryChange = {
   owner_ids?: Array<ID>,
   follower_ids?: Array<ID>,
   epic_id?: ID,
+  iteration_id?: ID,
   story_type: StoryType,
   estimate?: number,
   deadline?: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -41,6 +41,11 @@ export default class Client {
   deleteLinkedFile(linkedFileID: ID): Promise<{}>
   listTeams(): Promise<Array<Team>>
   getTeam(teamID: ID): Promise<Team>
+  listIterations(): Promise<Array<Iteration>>
+  createIteration(storyID: ID, params: IterationChange): Promise<Iteration>
+  getIteration(storyID: ID, iterationID: ID): Promise<Iteration>
+  updateIteration(storyID: ID, iterationID: ID, params: IterationChange): Promise<Iteration>
+  deleteIteration(storyID: ID, iterationID: ID): Promise<{}>
 }
 
 export function create(token: string, config?: any): Client
@@ -427,5 +432,42 @@ export type Team = {
   project_ids: Array<ID>;
   updated_at: string;
   workflow: Workflow;
+};
+
+/* Iterations */
+export type Iteration = {
+  created_at: string;
+  updated_at: string;
+  start_date: string;
+  end_date: string;
+  description: string;
+  id: ID;
+  name: string;
+  entity_type: string;
+  status: string;
+  follower_ids: Array<ID>;
+  mention_ids: Array<ID>;
+  stats: IterationStats;
+};
+
+export type IterationStats = {
+  average_cycle_time: number;
+  average_lead_time: number;
+  num_points: number;
+  num_points_done: number;
+  num_points_started: number;
+  num_points_unstarted: number;
+  num_stories_done: number;
+  num_stories_started: number;
+  num_stories_unestimated: number;
+  num_stories_unstarted: number
+};
+
+export type IterationChange = {
+  name?: string;
+  description?: string;
+  start_date?: string;
+  end_date?: string;
+  follower_ids?: Array<ID>;
 };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,10 +42,10 @@ export default class Client {
   listTeams(): Promise<Array<Team>>
   getTeam(teamID: ID): Promise<Team>
   listIterations(): Promise<Array<Iteration>>
-  createIteration(storyID: ID, params: IterationChange): Promise<Iteration>
-  getIteration(storyID: ID, iterationID: ID): Promise<Iteration>
-  updateIteration(storyID: ID, iterationID: ID, params: IterationChange): Promise<Iteration>
-  deleteIteration(storyID: ID, iterationID: ID): Promise<{}>
+  createIteration(params: IterationChange): Promise<Iteration>
+  getIteration(iterationID: ID): Promise<Iteration>
+  updateIteration(iterationID: ID, params: IterationChange): Promise<Iteration>
+  deleteIteration(iterationID: ID): Promise<{}>
 }
 
 export function create(token: string, config?: any): Client
@@ -281,6 +281,7 @@ export type Story = {
   owner_ids: Array<ID>;
   follower_ids: Array<ID>;
   epic_id: ID;
+  iteration_id: ID;
   tasks_id: Array<ID>;
   app_url: string;
 };
@@ -300,6 +301,7 @@ export type StoryChange = {
   owner_ids?: Array<ID>;
   follower_ids?: Array<ID>;
   epic_id?: ID;
+  iteration_id?: ID;
   story_type: StoryType;
   estimate?: number;
   deadline?: string;
@@ -435,20 +437,6 @@ export type Team = {
 };
 
 /* Iterations */
-export type Iteration = {
-  created_at: string;
-  updated_at: string;
-  start_date: string;
-  end_date: string;
-  description: string;
-  id: ID;
-  name: string;
-  entity_type: string;
-  status: string;
-  follower_ids: Array<ID>;
-  mention_ids: Array<ID>;
-  stats: IterationStats;
-};
 
 export type IterationStats = {
   average_cycle_time: number;
@@ -460,7 +448,24 @@ export type IterationStats = {
   num_stories_done: number;
   num_stories_started: number;
   num_stories_unestimated: number;
-  num_stories_unstarted: number
+  num_stories_unstarted: number;
+};
+
+export type IterationStatus = 'unstarted' | 'started' | 'done';
+
+export type Iteration = {
+  created_at: string;
+  updated_at: string;
+  start_date: string;
+  end_date: string;
+  description: string;
+  id: ID;
+  name: string;
+  entity_type: string;
+  status: IterationStatus;
+  follower_ids: Array<ID>;
+  mention_ids: Array<ID>;
+  stats: IterationStats;
 };
 
 export type IterationChange = {


### PR DESCRIPTION
This adds the necessary `iteration_id` to the `Story` typing.

This also removes an errant/incorrect `storyID` parameter from Iteration calls.