### PR TITLE
Fix TypeScript definition generation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "airbnb",
     "plugin:flowtype/recommended",
     "prettier",
-    "prettier/flowtype",
+    "prettier/flowtype"
   ],
   "parser": "babel-eslint",
   "plugins": [
@@ -17,11 +17,6 @@
     "es6": true
   },
    "rules": {
-      "no-undef": 0,
-      "prettier/prettier": [2, {
-        "trailingComma": "all",
-        "singleQuote": true,
-        "parser": "flow",
-      }]
+      "no-undef": 0
    }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "parser": "flow",
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "lint": "eslint src",
     "prepublish": "npm run build",
     "test": "jest",
-    "test:format": "prettier --list-different --single-quote --trailing-comma all --write src/**/*.js",
+    "test:format": "prettier --list-different --write src/**/*.js",
     "test:typescript": "scripts/ts-check.sh",
     "flow": "flow",
-    "format": "prettier --single-quote --trailing-comma all --write src/**/*.js",
+    "format": "prettier --write src/**/*.js",
     "ci": "npm run lint && npm run flow && npm test && npm run test:format && npm run test:typescript && npm run build"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "flow-bin": "^0.55.0",
     "flow-copy-source": "^1.2.1",
     "jest": "^21.2.0",
-    "prettier": "^1.16.4",
+    "prettier": "^1.18.2",
     "save": "^2.3.1",
     "typescript": "^3.4.0"
   },

--- a/scripts/ts-generate-definition.js
+++ b/scripts/ts-generate-definition.js
@@ -12,12 +12,11 @@ fs.readFile(clientFile, 'utf8', (err, data) => {
     process.exit(2);
   }
 
-  let clientMethods = data.split('\n')
-    .filter(line => line.match(/^  \w.*(.*): .*{$/))
-    .map(line => line
-      .replace(/ {$/, '')
-      .replace(': ?', '?: ')
-    ).join('\n');
+  const clientMethods = data
+    .split('\n')
+    .filter(line => line.match(/^ {2}(?!static create)\w.*(.*): .*{$/))
+    .map(line => line.replace(/ {$/, '').replace(': ?', '?: '))
+    .join('\n');
 
   fs.readFile(typesFile, 'utf8', (err, data) => {
     if (err) {
@@ -25,13 +24,16 @@ fs.readFile(clientFile, 'utf8', (err, data) => {
       process.exit(2);
     }
 
-    const types = data.split('\n')
-      .map(line => line
-        .replace('/\* @flow \*/', '')
-        .replace(/,$/, ';')
-        .replace(/<\*>/g, '<any>')
-        .replace(': ?', '?: ')
-      ).join('\n');
+    const types = data
+      .split('\n')
+      .map(line =>
+        line
+          .replace('/* @flow */', '')
+          .replace(/,$/, ';')
+          .replace(/<\*>/g, '<any>')
+          .replace(': ?', '?: '),
+      )
+      .join('\n');
 
     const result = `export default class Client {
 ${clientMethods}

--- a/src/TokenRequestFactory.js
+++ b/src/TokenRequestFactory.js
@@ -35,9 +35,7 @@ class TokenRequestFactory implements RequestFactory<Request> {
 
     if (method === 'GET') {
       if (body) {
-        Object.entries(body).forEach(entry =>
-          url.searchParams.append(entry[0], String(entry[1])),
-        );
+        Object.entries(body).forEach(entry => url.searchParams.append(entry[0], String(entry[1])));
       }
       return new Request(url.toString(), {
         headers,

--- a/src/__tests__/TokenRequestFactory-tests.js
+++ b/src/__tests__/TokenRequestFactory-tests.js
@@ -7,11 +7,7 @@ require('fetch-everywhere');
 describe('TokenRequestFactory', () => {
   describe('GET Requests', () => {
     it('correctly combines query parameters', () => {
-      const factory = new TokenRequestFactory(
-        'abc-123',
-        'https://api.clubhouse.io',
-        'v3',
-      );
+      const factory = new TokenRequestFactory('abc-123', 'https://api.clubhouse.io', 'v3');
       const request = factory.createRequest('search/stories', 'GET', {
         query: 'project:mobile',
       });
@@ -26,17 +22,11 @@ describe('TokenRequestFactory', () => {
 
   describe('POST/PUT Requests', () => {
     it('correctly combines query parameters', () => {
-      const factory = new TokenRequestFactory(
-        'abc-123',
-        'https://api.clubhouse.io',
-        'v3',
-      );
+      const factory = new TokenRequestFactory('abc-123', 'https://api.clubhouse.io', 'v3');
       const request = factory.createRequest('search/stories', 'POST', {
         query: 'project:mobile',
       });
-      expect(request.url).toEqual(
-        'https://api.clubhouse.io/api/v3/search/stories?token=abc-123',
-      );
+      expect(request.url).toEqual('https://api.clubhouse.io/api/v3/search/stories?token=abc-123');
       // $FlowFixMe
       expect(JSON.parse(request.body)).toEqual({
         query: 'project:mobile',

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -2,11 +2,7 @@
 
 import Client from '../index';
 
-import type {
-  RequestFactory,
-  RequestPerformer,
-  ResponseParser,
-} from '../types';
+import type { RequestFactory, RequestPerformer, ResponseParser } from '../types';
 
 type TestRequest = {
   uri: string,
@@ -16,13 +12,7 @@ type TestRequest = {
 
 // As per ECMA-404 spec: http://www.json.org/
 // and RFC-7159 spec: https://tools.ietf.org/html/rfc7159
-type JSON =
-  | { [keys: string]: JSON }
-  | Array<JSON>
-  | string
-  | number
-  | boolean
-  | null;
+type JSON = { [keys: string]: JSON } | Array<JSON> | string | number | boolean | null;
 
 type TestResponse = {
   status: number,
@@ -46,8 +36,7 @@ export class TestRequestFactory implements RequestFactory<TestRequest> {
 
 type PromiseResolver<Input, Output> = Input => Promise<Output>;
 
-export class TestRequestPerformer
-  implements RequestPerformer<TestRequest, TestResponse> {
+export class TestRequestPerformer implements RequestPerformer<TestRequest, TestResponse> {
   static resolve = (request: TestRequest, response: TestResponse) =>
     new TestRequestPerformer(() => Promise.resolve(response));
 
@@ -60,8 +49,7 @@ export class TestRequestPerformer
 
   resolver: PromiseResolver<TestRequest, TestResponse>;
 
-  performRequest = (request: TestRequest): Promise<TestResponse> =>
-    this.resolver(request);
+  performRequest = (request: TestRequest): Promise<TestResponse> => this.resolver(request);
 }
 
 export class TestResponseParser implements ResponseParser<TestResponse> {
@@ -77,14 +65,12 @@ export class TestResponseParser implements ResponseParser<TestResponse> {
 
   resolver: PromiseResolver<TestResponse, *>;
 
-  parseResponse = (response: TestResponse): Promise<*> =>
-    this.resolver(response);
+  parseResponse = (response: TestResponse): Promise<*> => this.resolver(response);
 }
 
 export const createTestClient = (
   requestPerformer: (request: TestRequest) => Promise<TestResponse>,
-  responseParser: (response: TestResponse) => Promise<*> = response =>
-    Promise.resolve(response),
+  responseParser: (response: TestResponse) => Promise<*> = response => Promise.resolve(response),
 ) =>
   new Client(
     new TestRequestFactory(),

--- a/src/index.js
+++ b/src/index.js
@@ -65,10 +65,7 @@ class Client<RequestType, ResponseType> {
     this.responseParser = responseParser;
   }
   /** */
-  static create(
-    token: string,
-    config?: ClientConfig = defaultConfig,
-  ): Client<Request, Response> {
+  static create(token: string, config?: ClientConfig = defaultConfig): Client<Request, Response> {
     const { baseURL, version } = config;
     return new Client(
       new TokenRequestFactory(token, baseURL, version),
@@ -79,39 +76,29 @@ class Client<RequestType, ResponseType> {
 
   listResource<T>(uri: string): Promise<Array<T>> {
     const request = this.requestFactory.createRequest(uri);
-    return this.requestPerformer
-      .performRequest(request)
-      .then(this.responseParser.parseResponse);
+    return this.requestPerformer.performRequest(request).then(this.responseParser.parseResponse);
   }
 
   getResource<T>(uri: string, params: ?Object): Promise<T> {
     const request = params
       ? this.requestFactory.createRequest(uri, 'GET', params)
       : this.requestFactory.createRequest(uri);
-    return this.requestPerformer
-      .performRequest(request)
-      .then(this.responseParser.parseResponse);
+    return this.requestPerformer.performRequest(request).then(this.responseParser.parseResponse);
   }
 
   createResource<T>(uri: string, params: Object): Promise<T> {
     const request = this.requestFactory.createRequest(uri, 'POST', params);
-    return this.requestPerformer
-      .performRequest(request)
-      .then(this.responseParser.parseResponse);
+    return this.requestPerformer.performRequest(request).then(this.responseParser.parseResponse);
   }
 
   updateResource<T>(uri: string, params: Object): Promise<T> {
     const request = this.requestFactory.createRequest(uri, 'PUT', params);
-    return this.requestPerformer
-      .performRequest(request)
-      .then(this.responseParser.parseResponse);
+    return this.requestPerformer.performRequest(request).then(this.responseParser.parseResponse);
   }
 
   deleteResource<T>(uri: string, params?: Object): Promise<T> {
     const request = this.requestFactory.createRequest(uri, 'DELETE', params);
-    return this.requestPerformer
-      .performRequest(request)
-      .then(this.responseParser.parseResponse);
+    return this.requestPerformer.performRequest(request).then(this.responseParser.parseResponse);
   }
 
   /** */
@@ -181,22 +168,16 @@ class Client<RequestType, ResponseType> {
 
   /** */
   addReaction(storyId: ID, commentId: ID, emoji: string): Promise<void> {
-    return this.createResource(
-      `stories/${storyId}/comments/${commentId}/reactions`,
-      {
-        emoji,
-      },
-    );
+    return this.createResource(`stories/${storyId}/comments/${commentId}/reactions`, {
+      emoji,
+    });
   }
 
   /** */
   deleteReaction(storyId: ID, commentId: ID, emoji: string): Promise<void> {
-    return this.deleteResource(
-      `stories/${storyId}/comments/${commentId}/reactions`,
-      {
-        emoji,
-      },
-    );
+    return this.deleteResource(`stories/${storyId}/comments/${commentId}/reactions`, {
+      emoji,
+    });
   }
 
   /** */
@@ -252,11 +233,7 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  updateStoryComment(
-    storyID: ID,
-    commentID: ID,
-    text: string,
-  ): Promise<StoryComment> {
+  updateStoryComment(storyID: ID, commentID: ID, text: string): Promise<StoryComment> {
     return this.updateResource(`stories/${storyID}/comments/${commentID}`, {
       text,
     });
@@ -333,10 +310,7 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  updateLinkedFile(
-    linkedFileID: ID,
-    params: LinkedFileChange,
-  ): Promise<LinkedFile> {
+  updateLinkedFile(linkedFileID: ID, params: LinkedFileChange): Promise<LinkedFile> {
     return this.updateResource(`linked-files/${linkedFileID}`, params);
   }
 
@@ -381,10 +355,7 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  updateIteration(
-    iterationID: ID,
-    params: IterationChange,
-  ): Promise<Iteration> {
+  updateIteration(iterationID: ID, params: IterationChange): Promise<Iteration> {
     return this.updateResource(`iterations/${iterationID}`, params);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -27,6 +27,7 @@ export default class Client {
   deleteStory(storyID: ID): Promise<{}>
   createStoryComment(storyID: ID, text: string): Promise<StoryComment>
   deleteStoryComment(storyID: ID, commentID: ID): Promise<{}>
+  updateStoryComment(storyID: ID, commentID: ID, text: string): Promise<StoryComment>
   listTasks(storyID: ID): Promise<Array<Task>>
   createTask(storyID: ID, params: TaskChange): Promise<Task>
   getTask(storyID: ID, taskID: ID): Promise<Task>
@@ -41,6 +42,7 @@ export default class Client {
   deleteFile(fileID: ID): Promise<{}>
   listLinkedFiles(): Promise<Array<LinkedFile>>
   createLinkedFile(params: LinkedFileChange): Promise<LinkedFile>
+  updateLinkedFile(linkedFileID: ID, params: LinkedFileChange): Promise<LinkedFile>
   deleteLinkedFile(linkedFileID: ID): Promise<{}>
   createLabel(name: string, color: string): Promise<any>
   listLabels(): Promise<Array<Label>>
@@ -49,6 +51,7 @@ export default class Client {
   listIterations(): Promise<Array<Iteration>>
   createIteration(params: IterationChange): Promise<Iteration>
   getIteration(iterationID: ID): Promise<Iteration>
+  updateIteration(iterationID: ID, params: IterationChange): Promise<Iteration>
   deleteIteration(iterationID: ID): Promise<{}>
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4187,10 +4187,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^21.2.0:
   version "21.2.0"


### PR DESCRIPTION
TypeScript definition was missing some methods, because of their definition being split into multiple lines. In order to prevent this, Prettier has been updated to the last version and will now allow up to a width of 100 characters. 

This is not optimal, and I'd love to have a more bulletproof script to generate TypeScript definition based on Flow.

cc @j-martin 