### PR TITLE
fix:dev: Fix Task complete typed field

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -231,7 +231,7 @@ export type Task = {
   id: ID;
   created_at: string;
   updated_at: string;
-  completed: boolean;
+  complete: boolean;
   completed_at: string;
   description: string;
   external_id?: string;


### PR DESCRIPTION
This `completed` field is incorrectly described in the type - it is coming back via the API as `complete`