### PR TITLE
Use prepublishOnly hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest",
     "test:format": "prettier --list-different --write src/**/*.js src/**/*.ts",
     "format": "prettier --write src/**/*.js src/**/*.ts",
-    "prepublish": "yarn build"
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "fetch-everywhere": "^1.0.5",


### PR DESCRIPTION
`prepublish` script is deprecated and it was triggered after an install.

Use `prepublishOnly` instead which will only be triggered before publishing.