### PR TITLE
Add partial types for UpdateXParams

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export type CreateLabelParams = {
   name: string;
 };
 
-export type UpdateLabelParams = Partial<CreateTaskParams>;
+export type UpdateLabelParams = Partial<CreateLabelParams>;
 
 export type Label = {
   archived: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,8 @@ export type CreateLabelParams = {
   name: string;
 };
 
+export type UpdateLabelParams = Partial<CreateTaskParams>;
+
 export type Label = {
   archived: boolean;
   color: string | null;
@@ -201,6 +203,8 @@ export type CreateTaskParams = {
   owner_ids?: Array<ID>;
   updated_at?: string;
 };
+
+export type UpdateTaskParams = Partial<CreateTaskParams>;
 
 export type Task = {
   complete: boolean;


### PR DESCRIPTION
Added [partial types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types) for `CreateTaskParams` and `CreateLabelParams` as `UpdateXParams` are the same, except with optional properties.