### PR TITLE
Fix CommonJS exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -400,3 +400,7 @@ class Client<RequestType, ResponseType> {
 }
 
 export default Client;
+
+// For CommonJS default export support
+module.exports = Client;
+module.exports.default = Client;


### PR DESCRIPTION
With that, we will be able to support:

```js
import Clubhouse from 'clubhouse-lib';
const Clubhouse = require('clubhouse-lib');
```

Without having to deal with defaults.