### PR TITLE
Export types from the root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ import {
   Workflow,
 } from './types';
 
+export * from './types';
+
 const API_BASE_URL = 'https://api.clubhouse.io';
 const API_VERSION = 'v3';
 


### PR DESCRIPTION
That way, we will be able to import types like this:

```js
// Flow
import { type Epic } from 'clubhouse-lib';

// TypeScript
import { Epic } from 'clubhouse-lib';
```