### PR TITLE
Update deprecated current user method/types to new current member structure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import FetchRequestParser from './FetchRequestParser';
 import {
   Comment,
   CreateTaskParams,
+  CurrentMember,
   Epic,
   EpicChange,
   File,

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,8 +131,8 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  getCurrentUser(): Promise<Member> {
-    return this.getResource('user');
+  getCurrentMember(): Promise<CurrentMember> {
+    return this.getResource('member');
   }
 
   /** */

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,18 @@ export type Member = {
   };
 };
 
+export type CurrentMember = {
+  id: ID;
+  mention_name: string;
+  name: string | null;
+  workspace2: MemberWorkspace;
+};
+
+export type MemberWorkspace = {
+  url_slug: string,
+  estimate_scale: Array<number>
+};
+
 /* Projects */
 
 export type Project = {


### PR DESCRIPTION
Ref: https://clubhouse.io/api/rest/v3/#Member

The `user` type a deprecated path/structure, but easily updated to the new current member structure.