### PR TITLE
fix reference to the old API

### DIFF
--- a/src/TokenRequestFactory.ts
+++ b/src/TokenRequestFactory.ts
@@ -18,10 +18,8 @@ class TokenRequestFactory implements RequestFactory<Request> {
 
   public prefixURI(uri: string): string {
     const prefix = `/api/${this.version}/`;
-    if (uri.startsWith(prefix)) {
-      return uri;
-    }
-    return `${prefix}${uri}`;
+    const sanitizedURI = uri.replace(/^\/api\/beta\/|^\/api\/v\d+\//, '')
+    return `${prefix}${sanitizedURI}`;
   }
 
   public createRequest(


### PR DESCRIPTION
There is a bug in the v3 API that returns the next URL which contains the path to `/api/beta`. This is a workaround this issue.