### PR TITLE
Make `story_type` optional in `StoryChange`.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -389,7 +389,7 @@ export type StoryChange = {
   owner_ids?: Array<ID>;
   project_id?: number;
   requested_by_id?: ID;
-  story_type: StoryType;
+  story_type?: StoryType;
   updated_at?: string | null;
   workflow_state_id?: number;
 };


### PR DESCRIPTION
Every other parameter is optional. I'm able to ignore it by casting a
`params` object as `any`, but I shouldn't have to do that.