### PR TITLE
Fix labels type in StoryChange

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -383,7 +383,7 @@ export type StoryChange = {
   file_ids?: Array<ID>;
   follower_ids?: Array<ID>;
   iteration_id?: number;
-  labels?: Array<Label>;
+  labels?: Array<CreateLabelParams>;
   linked_file_ids?: Array<ID>;
   name?: string;
   owner_ids?: Array<ID>;


### PR DESCRIPTION
The type of _labels_ in **StoryChange** class, which is used for createStory and updateStory, should be Array\<CreateLabelParams\> instead of Array\<Label\>, as illustrated at https://clubhouse.io/api/rest/v3/#Create-Story

<img width="419" alt="Screen Shot 2020-07-14 at 11 35 18 PM" src="https://user-images.githubusercontent.com/28539235/87511759-bbce3180-c62a-11ea-855c-d57b7e2263fc.png">

Before fixing, passing an Array\<Label\> will receive "Error 400: Schema mismatch".