### PR TITLE
Bump CircleCI's node version to the latest LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/clubhouse-lib
   docker:
-    - image: circleci/node:12
+    - image: circleci/node:14
 
 version: 2
 jobs:


### PR DESCRIPTION
Bumping CircleCI's node version to the latest LTS (14).