### PR TITLE
Add external_links to Story type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -345,6 +345,7 @@ export type Story = {
   epic_id: number | null;
   estimate: number | null;
   external_id: string | null;
+  external_links: Array<string>;
   external_tickets: Array<ExternalTicket>;
   files: Array<File>;
   follower_ids: Array<ID>;


### PR DESCRIPTION
Resolves #86 and resolves #90.

Add missing `external_links` to Story type.