### PR TITLE
Support includes_description in listStories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,11 +82,11 @@ class Client<RequestType, ResponseType> {
     );
   }
 
-  listResource<T>(uri: string): Promise<Array<T>> {
-    const request = this.requestFactory.createRequest(uri);
-    return this.requestPerformer
-      .performRequest(request)
-      .then(this.responseParser.parseResponse);
+  listResource<T>(
+    uri: string,
+    params?: Record<string, any> | null | undefined,
+  ): Promise<Array<T>> {
+    return this.getResource(uri, params);
   }
 
   getResource<T>(
@@ -213,8 +213,13 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  listStories(projectID: ID): Promise<Array<Story>> {
-    return this.listResource(`projects/${projectID}/stories`);
+  listStories(
+    projectID: ID,
+    includesDescription: boolean,
+  ): Promise<Array<Story>> {
+    return this.listResource(`projects/${projectID}/stories`, {
+      includes_description: Boolean(includesDescription),
+    });
   }
 
   /** */

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ class Client<RequestType, ResponseType> {
   /** */
   listStories(
     projectID: ID,
-    includesDescription: boolean,
+    includesDescription?: boolean,
   ): Promise<Array<Story>> {
     return this.listResource(`projects/${projectID}/stories`, {
       includes_description: Boolean(includesDescription),


### PR DESCRIPTION
Resolves #80.

[`List Stories`](https://clubhouse.io/api/rest/v3/#List-Stories) is returning an array of [`StorySlim`](https://clubhouse.io/api/rest/v3/#StorySlim) and by default, the `description` field isn't included. We can support this by passing `includes_description` as an argument.